### PR TITLE
#(331) Add Method to Retrieve a Single Donator

### DIFF
--- a/src/fund.cairo
+++ b/src/fund.cairo
@@ -33,7 +33,7 @@ pub trait IFund<TContractState> {
     fn get_contact_handle(self: @TContractState) -> ByteArray;
     fn set_type(ref self: TContractState, fund_type: u8);
     fn get_type(self: @TContractState) -> u8;
-    fn get_single_donator_amount(self: @TContractState, donator: ContractAddress) -> u256;
+    fn get_single_donator_by_address(self: @TContractState, donator: ContractAddress) -> DonatorInfo;
 }
 
 #[starknet::contract]
@@ -343,9 +343,10 @@ pub mod Fund {
             return self.fund_type.read();
         }
 
-        fn get_single_donator_amount(self: @ContractState, donator: ContractAddress) -> u256 {
-            //if the donator address is not found in the map , it will return 0
-            return self.donators.read(donator);
+        fn get_single_donator_by_address(self: @ContractState, donator: ContractAddress) ->  DonatorInfo {
+            //if the donator address is not found in the map , it will return 
+            // DonatorInfo { donator_index: 0, donator_address: 0x0, donator_amount: 0 }
+            self.donators.read(donator)
         }
     }
     // *************************************************************************

--- a/src/fund.cairo
+++ b/src/fund.cairo
@@ -25,6 +25,7 @@ pub trait IFund<TContractState> {
     fn get_contact_handle(self: @TContractState) -> ByteArray;
     fn set_type(ref self: TContractState, fund_type: u8);
     fn get_type(self: @TContractState) -> u8;
+    fn get_single_donator_amount( self: @TContractState, donator: ContractAddress) -> u256;
 }
 
 #[starknet::contract]
@@ -304,6 +305,11 @@ pub mod Fund {
         }
         fn get_type(self: @ContractState) -> u8 {
             return self.fund_type.read();
+        }
+
+        fn get_single_donator_amount( self: @ContractState, donator: ContractAddress) -> u256 {
+            //if the donator address is not found in the map , it will return 0
+            return self.donators.read(donator);
         }
     }
     // *************************************************************************

--- a/src/fund.cairo
+++ b/src/fund.cairo
@@ -344,8 +344,6 @@ pub mod Fund {
         }
 
         fn get_single_donator_by_address(self: @ContractState, donator: ContractAddress) ->  DonatorInfo {
-            //if the donator address is not found in the map , it will return 
-            // DonatorInfo { donator_index: 0, donator_address: 0x0, donator_amount: 0 }
             self.donators.read(donator)
         }
     }

--- a/src/fund.cairo
+++ b/src/fund.cairo
@@ -25,7 +25,7 @@ pub trait IFund<TContractState> {
     fn get_contact_handle(self: @TContractState) -> ByteArray;
     fn set_type(ref self: TContractState, fund_type: u8);
     fn get_type(self: @TContractState) -> u8;
-    fn get_single_donator_amount( self: @TContractState, donator: ContractAddress) -> u256;
+    fn get_single_donator_amount(self: @TContractState, donator: ContractAddress) -> u256;
 }
 
 #[starknet::contract]
@@ -307,7 +307,7 @@ pub mod Fund {
             return self.fund_type.read();
         }
 
-        fn get_single_donator_amount( self: @ContractState, donator: ContractAddress) -> u256 {
+        fn get_single_donator_amount(self: @ContractState, donator: ContractAddress) -> u256 {
             //if the donator address is not found in the map , it will return 0
             return self.donators.read(donator);
         }


### PR DESCRIPTION
# Pull Request

- [x] Closes # https://github.com/undefinedorgcr/gostarkme-backend/issues/331
- [ ] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [x] Commented the code

## Changes description

- The function get_single_donator_amount was defined in the contract trait
- The function returns the current value in  donators map according to the address entered or zero if not found.
- It was tested locally.

## Current output

![image](https://github.com/user-attachments/assets/985d6e5a-32cd-41c8-ba48-1fd9b9cfeb20)
![image](https://github.com/user-attachments/assets/666b26ce-58df-427f-8b38-d61cafdc7839)
![image](https://github.com/user-attachments/assets/ff61ced6-15de-41ff-a517-24711f621a56)

## Time spent breakdown

Around an hour. 

## Comments

The test was no implemented due to there is another issue to test the function. 
