### PR TITLE
Feat: Add fund_owner mapping and register owner in new_fund

### DIFF
--- a/src/fund_manager.cairo
+++ b/src/fund_manager.cairo
@@ -42,6 +42,7 @@ pub mod FundManager {
         current_id: u128,
         funds: LegacyMap::<u128, ContractAddress>,
         fund_class_hash: ClassHash,
+        fund_owner: LegacyMap::<ContractAddress, ContractAddress>,
     }
 
     // ***************************************************************************************
@@ -104,6 +105,7 @@ pub mod FundManager {
                 .unwrap();
 
             self.funds.write(self.current_id.read(), new_fund_address);
+            self.fund_owner.write(new_fund_address, get_caller_address());
             self
                 .emit(
                     FundDeployed {


### PR DESCRIPTION
# Pull Request

- [x] Closes #348 
- [ ] Added tests (if necessary)
- [ ] Run tests
- [x] Run formatting
- [x] Commented the code

## Changes description

• Introduce a LegacyMap to store the relationship between deployed fund contracts and their owners
• Update the new_fund method to register the caller address for each new fund

## Time spent breakdown

24 hours

## Comments

Thanks for the opportunity
